### PR TITLE
Display current directory as a placeholder for better UX

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -104,12 +104,12 @@ async function directoryListingAt(
         `${item.isDirectory() ? DIRECTORY_PREFIX : FILE_PREFIX}${item.name}`
     );
 
-  const result = await withCallback([
-    "..",
-    ...fileDisplayNames,
-    "Create Folder",
-    "Create File",
-  ]);
+  const result = await withCallback(
+    ["..", ...fileDisplayNames, "Create Folder", "Create File"],
+    {
+      placeholder: dirPath,
+    }
+  );
 
   switch (result) {
     case "..":


### PR DESCRIPTION
With placeholder it is a bit easier to understand in which folder is the user at the moment
![image](https://user-images.githubusercontent.com/10818831/126162953-8c66f4ae-15da-472c-94c6-9e5bcfc5fe2e.png)
